### PR TITLE
Add HalfLetter and QuarterLetter to recognized paper sizes (BL-2677)

### DIFF
--- a/src/GeckofxHtmlToPDFComponent.cs
+++ b/src/GeckofxHtmlToPDFComponent.cs
@@ -152,7 +152,10 @@ namespace GeckofxHtmlToPdf
 					new PaperSize("b5", 176, 250),
 					new PaperSize("b6", 125, 176),
 					new PaperSize("letter", 215.9, 279.4),
-					new PaperSize("legal", 215.9, 355.6)
+					new PaperSize("halfletter", 139.7, 215.9),
+					new PaperSize("quarterletter", 107.95, 139.7),
+					new PaperSize("legal", 215.9, 355.6),
+					new PaperSize("halflegal", 177.8, 215.9)
 				};
 
 			var match =sizes.Find(s => s.Name == name);


### PR DESCRIPTION
Note that the comparison of size names follows a "ToLower()" operation.